### PR TITLE
attention seq2seqを実装した。

### DIFF
--- a/src/array_util.rs
+++ b/src/array_util.rs
@@ -1,5 +1,5 @@
 use ndarray::{
-    Array, Array1, Array2, Array3, ArrayView1, Axis, Dimension, Ix2, Ix3, RemoveAxis, Slice,
+    s, Array, Array1, Array2, Array3, ArrayView1, Axis, Dimension, Ix2, Ix3, RemoveAxis, Slice,
 };
 
 pub trait AxisUtil {
@@ -58,15 +58,19 @@ impl<T, D: Dimension> ReshapeUtil<T> for Array<T, D> {
             .unwrap()
     }
 }
-#[test]
 fn reshape_test() {
     let arr = Array::from_shape_fn((2, 3, 4), |(i, j, k)| 12 * i + 4 * j + k);
     putsl!(arr, arr.reshape2::<Ix3>(&[4, 1, -1]));
 }
-#[test]
 fn merge_axis_test() {
     let mut arr = Array::from_shape_fn((3, 1, 4), |(i, j, k)| 12 * i + 4 * j + k);
     let merged = arr.merge_axes(Axis(0), Axis(2));
     putsl!(merged, arr);
     putsl!(arr.index_axis_move(Axis(0), 0));
+}
+#[test]
+fn slice_test() {
+    let mut arr = Array::from_shape_fn((3, 1, 4), |(i, j, k)| 12 * i + 4 * j + k);
+    putsl!(arr);
+    putsl!(arr.slice_move(s![..,..,..;-1]));
 }

--- a/src/array_util.rs
+++ b/src/array_util.rs
@@ -1,0 +1,65 @@
+use ndarray::{
+    Array, Array1, Array2, Array3, ArrayView1, Axis, Dimension, Ix2, Ix3, RemoveAxis, Slice,
+};
+
+pub trait AxisUtil {
+    type T;
+    type D: Dimension;
+    fn remove_axis(self, axis: Axis) -> Array<Self::T, Self::D>;
+}
+
+impl<T, D: RemoveAxis> AxisUtil for Array<T, D> {
+    type T = T;
+    type D = D::Smaller;
+    fn remove_axis(self, axis: Axis) -> Array<T, D::Smaller> {
+        let mut d = self.shape().to_vec();
+        let f = d.remove(axis.0);
+        d[axis.0] *= f;
+        self.into_shape(d).unwrap().into_dimensionality().unwrap()
+    }
+}
+
+#[test]
+fn axisutil_test() {
+    let arr = Array::from_elem((2, 3, 4), 0);
+    // putsd!(arr.clone().remove_axis(Axis(0)));
+    // putsd!(arr.clone().remove_axis(Axis(1)));
+    // putsd!(arr.clone().remove_axis(Axis(2)));
+}
+
+use std::convert::TryInto;
+pub trait ReshapeUtil<T> {
+    fn reshape2<D: Dimension>(self, shape: &[i32]) -> Array<T, D>;
+}
+impl<T, D: Dimension> ReshapeUtil<T> for Array<T, D> {
+    fn reshape2<D2: Dimension>(self, shape: &[i32]) -> Array<T, D2> {
+        let shape = match shape.iter().position(|i| *i == -1) {
+            Some(x) => {
+                let mut v = shape.to_vec();
+                v.remove(x);
+                let mut v = v
+                    .iter()
+                    .map(|_v| (*_v).try_into())
+                    .collect::<Result<Vec<usize>, _>>()
+                    .expect("you can contain only one -1!");
+                let otherdim = v.iter().fold(1, |a, b| a * b);
+                v.insert(x, self.len() / otherdim);
+                v
+            }
+            None => shape
+                .iter()
+                .map(|_v| (*_v).try_into())
+                .collect::<Result<Vec<usize>, _>>()
+                .expect("you can contain only one -1!"),
+        };
+        self.into_shape(shape)
+            .unwrap()
+            .into_dimensionality()
+            .unwrap()
+    }
+}
+#[test]
+fn reshape_test() {
+    let arr = Array::from_shape_fn((2, 3, 4), |(i, j, k)| 12 * i + 4 * j + k);
+    putsl!(arr, arr.reshape2::<Ix3>(&[4, 3, 2]));
+}

--- a/src/array_util.rs
+++ b/src/array_util.rs
@@ -61,5 +61,12 @@ impl<T, D: Dimension> ReshapeUtil<T> for Array<T, D> {
 #[test]
 fn reshape_test() {
     let arr = Array::from_shape_fn((2, 3, 4), |(i, j, k)| 12 * i + 4 * j + k);
-    putsl!(arr, arr.reshape2::<Ix3>(&[4, 3, 2]));
+    putsl!(arr, arr.reshape2::<Ix3>(&[4, 1, -1]));
+}
+#[test]
+fn merge_axis_test() {
+    let mut arr = Array::from_shape_fn((3, 1, 4), |(i, j, k)| 12 * i + 4 * j + k);
+    let merged = arr.merge_axes(Axis(0), Axis(2));
+    putsl!(merged, arr);
+    putsl!(arr.index_axis_move(Axis(0), 0));
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -63,18 +63,3 @@ pub fn normalize<D: RemoveAxis>(m: Array<f32, D>) -> Array<f32, D> {
         + 1e-7;
     m / nm
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use ndarray::{arr1, arr2};
-    #[test]
-    fn cross_entropy_error_test() {
-        let pred: Arr2d = arr2(&[[1.0, 2.0, 3.0]]);
-        let target: Array1<usize> = arr1(&[1]);
-        let one_hot_target: Arr2d = arr2(&[[0.0, 1.0, 0.0]]);
-        println!("onehot: {}", cross_entropy_error(&pred, &one_hot_target));
-        println!("reverse: {}", reverse_one_hot(&one_hot_target));
-        println!("index: {}", cross_entropy_error_target(&pred, &target));
-    }
-}

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -22,6 +22,13 @@ pub fn softmax(input: Arr2d) -> Arr2d {
     let sum = input.sum_axis(Axis(1));
     input / sum.insert_axis(Axis(1))
 }
+pub fn softmaxd<D: RemoveAxis>(input: Array<f32, D>) -> Array<f32, D> {
+    // input - input.max(Axis(1))
+    let ndim = input.ndim();
+    let input = input.mapv(|x| x.exp());
+    let sum = input.sum_axis(Axis(ndim - 1));
+    input / sum.insert_axis(Axis(ndim - 1))
+}
 
 pub fn cross_entropy_error_target(pred: &Arr2d, target: &Array1<usize>) -> f32 {
     let mut entropy = Array::zeros(target.len());

--- a/src/io.rs
+++ b/src/io.rs
@@ -183,25 +183,21 @@ where
     Ok(v)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[test]
-    fn read_csv_test() {
-        // // let v: Vec<Vec<f32>> = read_csv("./data/spiral/x.csv").unwrap();
-        // // let arr = Array::from_shape_fn((v.len(), 2), |(i, j)| v[i][j]);
-        // let arr = csv_to_array::<f32>("./data/spiral/t.csv").unwrap();
-        // // println!("{:?}", arr);
-        // // let c = read_csv::<(usize, String)>("./data/ptb/id.csv").expect("error!!!");
-        // arr.save_as_csv("hoge.csv");
-        // // putsl!(c);
-        // use ndarray::Array1;
-        // Array1::<f32>::zeros((10,)).save_as_csv("zerozero.csv");
+#[test]
+fn read_csv_test() {
+    // // let v: Vec<Vec<f32>> = read_csv("./data/spiral/x.csv").unwrap();
+    // // let arr = Array::from_shape_fn((v.len(), 2), |(i, j)| v[i][j]);
+    // let arr = csv_to_array::<f32>("./data/spiral/t.csv").unwrap();
+    // // println!("{:?}", arr);
+    // // let c = read_csv::<(usize, String)>("./data/ptb/id.csv").expect("error!!!");
+    // arr.save_as_csv("hoge.csv");
+    // // putsl!(c);
+    // use ndarray::Array1;
+    // Array1::<f32>::zeros((10,)).save_as_csv("zerozero.csv");
 
-        let arr = csv_to_array::<f32>(
-            "/Users/kamohara_jun/Documents/projects/dlfs/rust/data/BetterRnnlm/affine_w.csv",
-        )
-        .unwrap();
-        putsd!(arr[[0, 0]]);
-    }
+    // let arr = csv_to_array::<f32>(
+    //     "/Users/kamohara_jun/Documents/projects/dlfs/rust/data/BetterRnnlm/affine_w.csv",
+    // )
+    // .unwrap();
+    // putsd!(arr[[0, 0]]);
 }

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -3,7 +3,7 @@ use super::functions::*;
 use super::types::{Arr1d, Arr2d, Arr3d};
 use crate::util::*;
 use itertools::izip;
-use ndarray::{Array, Array1, Array2, Array3, Axis, Dimension, RemoveAxis};
+use ndarray::{s, Array, Array1, Array2, Array3, Axis, Dimension, RemoveAxis};
 pub mod loss_layer;
 pub mod negativ_sampling_layer;
 pub mod time_layers;
@@ -320,5 +320,58 @@ impl<D: RemoveAxis> SoftMaxD<D> {
     fn backward(&mut self, dout: Array<f32, D>) -> Array<f32, D> {
         let outdout = &(self.out) * &dout; // 演算の中間に出てくる値
         outdout.clone() - (&self.out * &(outdout.sum_axis(Axis(self.ndim - 1))))
+    }
+}
+/// 1, 2のどの次元を潰すかは、自由に決めれそうな気がするが...
+/// viewという便利なものを使って実現
+fn dot3d(x: &Arr3d, y: &Arr3d, xaxis: usize, yaxis: usize) -> Arr3d {
+    let mut x = x.view();
+    let mut y = y.view();
+    if xaxis == 1 {
+        x.swap_axes(1, 2);
+    }
+    if yaxis == 1 {
+        y.swap_axes(1, 2);
+    }
+    let (b, left, h) = x.dim();
+    let (b_, right, h_) = y.dim();
+    assert_eq!((b, h), (b_, h_), "batch and hidden size must coincide!");
+    Arr3d::from_shape_fn((b, left, right), |(b, l, r)| {
+        x.slice(s![b, l, ..]).dot(&y.slice(s![b, r, ..]))
+    })
+}
+#[derive(Default)]
+pub struct MatMul3D {
+    xs: (Arr3d, Arr3d),
+    swap_axes: (bool, bool), // 入力時にaxis1, axis2を入れ替えるか否か
+}
+impl MatMul3D {
+    pub fn new(swap_left: bool, swap_right: bool) -> Self {
+        let swap_axes = (swap_left, swap_right);
+        Self {
+            swap_axes,
+            ..Self::default()
+        }
+    }
+    fn swap(&self, mut xs: (Arr3d, Arr3d)) -> (Arr3d, Arr3d) {
+        if self.swap_axes.0 {
+            xs.0.swap_axes(1, 2);
+        }
+        if self.swap_axes.1 {
+            xs.1.swap_axes(1, 2);
+        }
+        xs
+    }
+    fn forward(&mut self, mut xs: (Arr3d, Arr3d)) -> Arr3d {
+        xs = self.swap(xs);
+        self.xs = xs.clone();
+        let (batch_size, left, _) = xs.0.dim();
+        let right = xs.1.dim().2;
+        dot3d(&xs.0, &xs.1, 2, 2)
+    }
+    fn backward(&mut self, dout: Arr3d) -> (Arr3d, Arr3d) {
+        let doutl = dot3d(&dout, &self.xs.1, 2, 1);
+        let doutr = dot3d(&dout, &self.xs.0, 1, 1);
+        self.swap((doutl, doutr))
     }
 }

--- a/src/layers/time_layers.rs
+++ b/src/layers/time_layers.rs
@@ -417,6 +417,12 @@ pub struct TimeAttention {
     attention: Arr3d,
 }
 impl TimeAttention {
+    pub fn new() -> Self {
+        Self {
+            matmul: [Default::default(), MatMul3D::new(false, true)],
+            ..Default::default()
+        }
+    }
     /// 入力 : (batch, enct, hidden), (batch, dect, hidden)
     pub fn forward(&mut self, enc_hs: Arr3d, dec_hs: Arr3d) -> Arr3d {
         self.dec_hs = dec_hs.clone();

--- a/src/layers/time_layers.rs
+++ b/src/layers/time_layers.rs
@@ -279,8 +279,9 @@ impl<'a> LSTM<'a> {
 }
 
 pub struct TimeLSTM<'a> {
-    h: Arr2d,       // 順伝播の時は、前回のhを用いる
-    c: Arr2d,       // 同様にcも用いる
+    h: Arr2d, // 順伝播の時は、前回のhを用いる
+    c: Arr2d, // 同様にcも用いる
+    /// dxとは別で、内部LSTMの相互入出力によるもの!
     pub dh: Arr2d, // 誤差逆伝播では基本的に勾配を渡すことはない(したがって1回のbackward関数内で保持すれば良い)のだが、encoder-decoderの時は、decoderからencoderに渡す必要がある。
     stateful: bool, // 前回のhを保持するかどうか
     pub time_size: usize,
@@ -387,9 +388,11 @@ impl<'a> TimeLSTM<'a> {
         self.dh = dh;
         dxs
     }
+    /// (batch*time, hidden) -> (batch, time, hidden)
     pub fn conv_2d_3d(&self, x: Arr2d) -> Arr3d {
-        let batch_size = x.len() / (self.time_size * self.hidden_size);
-        x.into_shape((batch_size, self.time_size, self.hidden_size))
+        let (batch_time, hidden_size) = x.dim();
+        let batch_size = batch_time / self.time_size;
+        x.into_shape((batch_size, self.time_size, hidden_size))
             .unwrap()
     }
     pub fn reset_state(&mut self) {
@@ -399,5 +402,18 @@ impl<'a> TimeLSTM<'a> {
     pub fn set_state(&mut self, h: Option<Arr2d>, c: Option<Arr2d>) {
         self.h = h.unwrap_or_default();
         self.c = c.unwrap_or_default();
+    }
+}
+
+pub struct TimeAttention<'a> {
+    x: &'a i32,
+}
+impl TimeAttention<'_> {
+    pub fn forward(&mut self, enc_hs: Arr3d, dec_hs: Arr3d) -> Arr3d {
+        unimplemented!();
+    }
+    /// dhs -> denc_hs, ddec_hs
+    pub fn backward(&mut self, dhs: Arr3d) -> (Arr3d, Arr3d) {
+        unimplemented!();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,15 +2,7 @@
 mod tests {
     use super::*;
     #[test]
-    fn it_works() {
-        let (contexts, target) = util::create_contexts_target(&vec![0, 1, 2, 3, 4, 1, 5, 6], 1);
-        let corpus = util::convert_one_hot_2(&contexts, 7);
-        let target = util::convert_one_hot_1(&target, 7);
-        println!(
-            "contexts={:?}, corpus={:?}, target={:?}",
-            contexts, corpus, target
-        );
-    }
+    fn it_works() {}
 }
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ mod tests {
 #[macro_use]
 pub mod macros;
 
+pub mod array_util;
 pub mod functions;
 pub mod io;
 pub mod layers;

--- a/src/model/rnn.rs
+++ b/src/model/rnn.rs
@@ -544,7 +544,7 @@ impl RnnlmGen for RnnlmLSTM<'_> {
 use rand::distributions::{Distribution, WeightedIndex};
 use rand::prelude::thread_rng;
 #[test]
-fn hello_rand() {
+fn rand_test() {
     let choices = ['a', 'b', 'c'];
     let weights = [2, 1, 0];
     let dist = WeightedIndex::new(&weights).unwrap();

--- a/src/model/rnn.rs
+++ b/src/model/rnn.rs
@@ -113,11 +113,38 @@ impl SimpleRnnlmParams {
         hidden_size: usize,
     ) -> Self {
         let embed_w = P1::new(randarr2d(vocab_size, wordvec_size) / 100.0);
+        // ランダムベクトル初期化用のクロージャ
         let mat_init = |m, n| randarr2d(m, n) / (m as f32).sqrt();
-        let rnn_wx = P1::new(mat_init(wordvec_size + hidden_size, 4 * hidden_size)); // rnnへの入力にEncoderからのhを追加
+        // rnnへの入力はembedからの(b, wordvec)とEncoderからの(b, hidden)
+        let rnn_wx = P1::new(mat_init(wordvec_size + hidden_size, 4 * hidden_size));
         let rnn_wh = P1::new(mat_init(hidden_size, 4 * hidden_size));
         let rnn_b = P1::new(Arr1d::zeros((4 * hidden_size,)));
-        let affine_w = P1::new(mat_init(hidden_size * 2, vocab_size)); // affineへの入力にEncoderからのhを追加
+        // rnnからの(b, hidden)とEncoderからの(b, hidden)
+        let affine_w = P1::new(mat_init(hidden_size * 2, vocab_size));
+        let affine_b = P1::new(Arr1d::zeros((vocab_size,)));
+        Self {
+            embed_w,
+            rnn_wx,
+            rnn_wh,
+            rnn_b,
+            affine_w,
+            affine_b,
+        }
+    }
+    pub fn new_for_AttentionDecoder(
+        vocab_size: usize,
+        wordvec_size: usize,
+        hidden_size: usize,
+    ) -> Self {
+        let embed_w = P1::new(randarr2d(vocab_size, wordvec_size) / 100.0);
+        // ランダムベクトル初期化用のクロージャ
+        let mat_init = |m, n| randarr2d(m, n) / (m as f32).sqrt();
+        // rnnへの入力はembedの(b, wordvec)
+        let rnn_wx = P1::new(mat_init(wordvec_size, 4 * hidden_size));
+        let rnn_wh = P1::new(mat_init(hidden_size, 4 * hidden_size));
+        let rnn_b = P1::new(Arr1d::zeros((4 * hidden_size,)));
+        // attentionからの(b, hidden)と、attention前のrnnの(b, hidden)
+        let affine_w = P1::new(mat_init(hidden_size * 2, vocab_size));
         let affine_b = P1::new(Arr1d::zeros((vocab_size,)));
         Self {
             embed_w,

--- a/src/train/ch08.rs
+++ b/src/train/ch08.rs
@@ -5,15 +5,16 @@ use crate::optimizer::{NewAdam, NewSGD};
 use crate::trainer::{RnnlmTrainer, Seq2SeqTrainer};
 use crate::types::*;
 use crate::util::*;
-use ndarray::{array, Array2, Axis, Ix2};
+use ndarray::{array, s, Array2, Axis, Ix2};
 use std::collections::HashMap;
 
 use itertools::concat;
+/// 例えば
 /// 16+75  _91  
 /// 52+607 _659
 /// 75+22  _97
 /// という形式の問題ファイルを受け取り、
-/// 問題, 答え, 記号一覧を返す
+/// 問題(_の手前まで), 答え(_以降), 記号一覧、記号->idを返す
 use std::collections::HashSet;
 fn load_additon_text(filename: &str) -> (Seq, Seq, Vec<char>, HashMap<char, usize>) {
     let raw = read_txt(filename).expect(&format!("couldn't load {}", filename));
@@ -39,13 +40,13 @@ fn train_seq2seq() {
     const MAX_EPOCH: usize = 25;
     const MAX_GRAD: f32 = 5.0;
     const LR: f32 = 0.001;
-    const REVERSED: bool = true;
-    let (mut x, t, chars, char_to_id) = load_additon_text("./data/addition.txt");
+    const REVERSED: bool = false;
+    let (mut x, t, chars, char_to_id) = load_additon_text("./data/date.txt");
     let input_len = x.dim().1;
-    if REVERSED {
-        // 入力反転
-        x = Array2::from_shape_fn((x.dim()), |(i, j)| x[[i, input_len - j - 1]]);
-    }
+    // if REVERSED {
+    //     // 入力反転
+    //     x = x.slice_move(s![..,..;-1]).to_owned();
+    // }
     putsl!(x.index_axis(Axis(0), 0), t.index_axis(Axis(0), 0), chars);
     let ((x_train, t_train), (x_test, t_test)) = test_train_split(x, t, (9, 1));
     putsl!(x_train.dim(), t_train.dim(), x_test.dim(), t_test.dim());
@@ -59,15 +60,12 @@ fn train_seq2seq() {
     println!("{}{}", out(&x_train, 3), out(&t_train, 3));
     println!("{}{}", out(&x_test, 4), out(&t_test, 4));
     let vocab_size = chars.len();
-    let encoder_time_size = input_len; // encoderの入力は計算式の左辺全体
+    let encoder_time_size = input_len; // encoderの入力は問題文の全体
     let decoder_time_size = t_train.dim().1 - 1; // decoderは右辺の入力から、一つずらしたものを出力するので、入力長は一つ短い
     let encoder_params = EncoderParams::new(vocab_size, WORDVEC_SIZE, HIDDEN_SIZE);
     let decoder_params =
-        SimpleRnnlmParams::new_for_PeekyDecoder(vocab_size, WORDVEC_SIZE, HIDDEN_SIZE);
-    // let decoder_params =
-    // SimpleRnnlmParams::new_for_Decoder(vocab_size, WORDVEC_SIZE, HIDDEN_SIZE);
-    // let model = Seq2Seq::<Encoder, Decoder>::new(
-    let model = Seq2Seq::<Encoder, PeekyDecoder>::new(
+        SimpleRnnlmParams::new_for_AttentionDecoder(vocab_size, WORDVEC_SIZE, HIDDEN_SIZE);
+    let model = Seq2Seq::<AttentionEncoder, AttentionDecoder>::new(
         encoder_time_size,
         decoder_time_size,
         &encoder_params,
@@ -88,7 +86,11 @@ fn train_seq2seq() {
         Some((x_test, t_test, chars)),
         REVERSED,
     );
-    // trainer.eval(&x_test, &t_test, &chars);
     trainer.print_ppl();
     trainer.print_acc();
+}
+
+#[test]
+fn test_ch08() {
+    train_seq2seq();
 }

--- a/src/train/mod.rs
+++ b/src/train/mod.rs
@@ -3,5 +3,5 @@
 // pub mod ch04;
 // pub mod ch05;
 // pub mod ch06;
-pub mod ch07;
+// pub mod ch07;
 pub mod ch08;

--- a/src/trainer.rs
+++ b/src/trainer.rs
@@ -107,7 +107,7 @@ impl<'a, E: Encode, D: Decode<Dim = E::Dim>> Seq2SeqTrainer<'a, E, D> {
             .enumerate()
         {
             let guess = self.model.generate(_x.to_owned(), start_id, sample_size);
-            self.params.iter().inspect(|p| p.reset_grads());
+            self.params.iter().inspect(|p| p.reset_grads()); // generateでもgrads保存してしまう仕様なので、全部消す
             let is_correct = _t.iter().zip(guess.iter()).all(|(a, g)| a == g); // answerとguessを比較
             correct_count += if is_correct { 1.0 } else { 0.0 };
             if i < 10 {

--- a/src/util.rs
+++ b/src/util.rs
@@ -340,13 +340,6 @@ pub fn remove_axis<T, D: RemoveAxis>(mut a: Array<T, D>) -> Array<T, D::Smaller>
     assert!(a.merge_axes(Axis(0), Axis(1)), "this must never happen!");
     a.index_axis_move(Axis(0), 0)
 }
-pub fn insert_axis<T, D: Dimension>(a: Array<T, D>, axis: Axis) -> Array<T, D::Larger> {
-    let mut d = a.shape().to_vec();
-    d.insert(axis.0, 1);
-    // a.into_shape(d)
-    // Default::default()
-    unimplemented!();
-}
 
 pub fn test_train_split<T: Zero + Copy, D: RemoveAxis>(
     x: Array<T, D>,

--- a/src/util.rs
+++ b/src/util.rs
@@ -136,15 +136,9 @@ pub fn randarr1d(m: usize) -> Arr1d {
     Array::<f32, _>::random((m,), StandardNormal)
 }
 pub fn randarr<D: Dimension>(dim: &[usize]) -> Array<f32, D> {
-    // Array::<f32, _>::random(dim, StandardNormal)
     Array::<f32, _>::random(dim, StandardNormal)
         .into_dimensionality()
         .unwrap()
-    // Default::default()
-}
-#[test]
-fn test_randarr() {
-    let a = randarr::<Ix2>(&[1, 2]);
 }
 
 extern crate num_traits;

--- a/src/util.rs
+++ b/src/util.rs
@@ -328,11 +328,17 @@ pub fn replace_item<T: Eq + Clone>(mut v: Vec<T>, prev: T, new: T) -> Vec<T> {
 }
 
 /// 先頭の軸を落とす
-pub fn remove_axis<T, D: RemoveAxis>(a: Array<T, D>) -> Array<T, D::Smaller> {
-    let mut d = a.shape().to_vec();
-    let f = d.remove(1);
-    d[0] *= f;
-    a.into_shape(d).unwrap().into_dimensionality().unwrap()
+pub fn remove_axis<T, D: RemoveAxis>(mut a: Array<T, D>) -> Array<T, D::Smaller> {
+    // let mut d = a.shape().to_vec();
+    // let f = d.remove(1);
+    // d[0] *= f;
+    // a.into_shape(d).unwrap().into_dimensionality().unwrap()
+    // merge_axesは、データの並び順を変えない場合に限って実行できる。
+    // 隣り合ったaxis同士なら可能で、外側の長さが1になる。
+    // 隣接していない場合は，間の軸がすべて長さ1の場合のみ実行可能。
+    // a.dim() = (3, 1, 1, 1, 5) -> Axis(0)からAxis(4)でok
+    assert!(a.merge_axes(Axis(0), Axis(1)), "this must never happen!");
+    a.index_axis_move(Axis(0), 0)
 }
 pub fn insert_axis<T, D: Dimension>(a: Array<T, D>, axis: Axis) -> Array<T, D::Larger> {
     let mut d = a.shape().to_vec();

--- a/src/util.rs
+++ b/src/util.rs
@@ -334,6 +334,13 @@ pub fn remove_axis<T, D: RemoveAxis>(a: Array<T, D>) -> Array<T, D::Smaller> {
     d[0] *= f;
     a.into_shape(d).unwrap().into_dimensionality().unwrap()
 }
+pub fn insert_axis<T, D: Dimension>(a: Array<T, D>, axis: Axis) -> Array<T, D::Larger> {
+    let mut d = a.shape().to_vec();
+    d.insert(axis.0, 1);
+    // a.into_shape(d)
+    // Default::default()
+    unimplemented!();
+}
 
 pub fn test_train_split<T: Zero + Copy, D: RemoveAxis>(
     x: Array<T, D>,


### PR DESCRIPTION
実装内容
seq2seqはencoderとdecoderを引数としてジェネリック化しているので、attention用のencoderとdecoderを実装すればok
attention encoderはforwardの出力で、lstmの最終層だけじゃなくて、全体(3darray)を渡すようにするだけ。文章全体の情報を出力するわけで、全く自然である。
attention decoderは、attention層の実装がメイン。
attention層ではMatMul層が役にたった。
3darrayの次元が、(batch, time, hidden)の順番なのだが、timeの先頭とか最後尾を抜き出す操作の際に、よく間違ってhidden層の最後を取り出して、ndarray cannot broad cast errorになった。